### PR TITLE
Add label for input wrapper Blade components

### DIFF
--- a/packages/support/docs/09-blade-components/02-dropdown.md
+++ b/packages/support/docs/09-blade-components/02-dropdown.md
@@ -117,7 +117,7 @@ You can [change the color](badge#changing-the-color-of-the-badge) of the badge u
 </x-filament::dropdown.list.item>
 ```
 
-## Addomg a separator to a dropdown list
+## Adding a separator to a dropdown list
 
 The dropdown may be positioned relative to the trigger button by using the `placement` attribute:
 

--- a/packages/support/docs/09-blade-components/02-dropdown.md
+++ b/packages/support/docs/09-blade-components/02-dropdown.md
@@ -22,6 +22,8 @@ The dropdown component allows you to render a dropdown menu with a button that t
         <x-filament::dropdown.list.item wire:click="openEditModal">
             Edit
         </x-filament::dropdown.list.item>
+
+        </x-filament::dropdown.list.separator />
         
         <x-filament::dropdown.list.item wire:click="openDeleteModal">
             Delete
@@ -115,14 +117,14 @@ You can [change the color](badge#changing-the-color-of-the-badge) of the badge u
 </x-filament::dropdown.list.item>
 ```
 
-## Setting the placement of a dropdown
+## Addomg a separator to a dropdown list
 
 The dropdown may be positioned relative to the trigger button by using the `placement` attribute:
 
 ```blade
-<x-filament::dropdown placement="top-start">
-    {{-- Dropdown items --}}
-</x-filament::dropdown>
+<x-filament::dropdown.list>
+    </x-filament::dropdown.list.separator />
+</x-filament::dropdown.list>
 ```
 
 ## Setting the width of a dropdown

--- a/packages/support/resources/views/components/dropdown/list/separator.blade.php
+++ b/packages/support/resources/views/components/dropdown/list/separator.blade.php
@@ -1,0 +1,4 @@
+<div
+    aria-hidden="true"
+    {{ $attributes->class(['-mx-1 my-1 border-t border-gray-950/5 dark:border-white/10']) }}
+></div>

--- a/packages/support/resources/views/components/input/wrapper.blade.php
+++ b/packages/support/resources/views/components/input/wrapper.blade.php
@@ -4,6 +4,7 @@
     'disabled' => false,
     'inlinePrefix' => false,
     'inlineSuffix' => false,
+    'label' => null,
     'prefix' => null,
     'prefixActions' => [],
     'prefixIcon' => null,
@@ -71,6 +72,17 @@
     }
 @endphp
 
+@if ($label)
+    <div class="fi-field-wrp grid gap-y-2">
+        <div class="flex items-center justify-between gap-x-3">
+            <label class="fi-field-wrp-label inline-flex items-center gap-x-3">
+                    <span class="text-sm font-medium leading-6 text-gray-950 dark:text-white">
+                        {{ $label }}
+                    </span>
+            </label>
+        </div>
+@endif
+    
 <div
     @if ($hasAlpineClasses)
         x-bind:class="{
@@ -210,3 +222,7 @@
         </div>
     @endif
 </div>
+
+@if ($label)
+    </div>
+@endif


### PR DESCRIPTION
## Description

This pull request introduces labels for Blade inputs, as this is currently not supported. By clearly associating text labels with input fields, we enhance user experience, making forms more intuitive and easier to navigate.

![screenshot-001250 (2024-02-16)@2x](https://github.com/mischasigtermans/filament/assets/22501510/cfafc9ee-01c6-4204-a7c3-6fbe063e9492)


## Code style

- [x] `composer cs` command has been run.

## Testing

- [x] Changes have been tested.

## Documentation

<!-- If new functionality has been added or existing functionality changed, please update the documentation. -->

- [x] Documentation is up-to-date.
